### PR TITLE
BLD: Add missing headers and CMake conditions

### DIFF
--- a/extensions/libjpeg_turbo/jpeg_handle.h
+++ b/extensions/libjpeg_turbo/jpeg_handle.h
@@ -1,16 +1,16 @@
-/* 
+/*
  * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright 2015 The TensorFlow Authors. All Rights Reserved.
  * Copyright 2019-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include "jpeg_utils.h"
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
-add_subdirectory(dlpack EXCLUDE_FROM_ALL)
+if(BUILD_PYTHON)
+    add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
+    add_subdirectory(dlpack EXCLUDE_FROM_ALL)
+endif(BUILD_PYTHON)

--- a/src/logger.h
+++ b/src/logger.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <nvimgcodec.h>
 #include <string>
 #include <vector>
@@ -46,7 +47,7 @@ class Logger : public ILogger
     }
 
     void log(const nvimgcodecDebugMessageSeverity_t message_severity,
-        const nvimgcodecDebugMessageCategory_t message_category, const std::string& message) override 
+        const nvimgcodecDebugMessageCategory_t message_category, const std::string& message) override
     {
         nvimgcodecDebugMessageData_t data{NVIMGCODEC_STRUCTURE_TYPE_DEBUG_MESSAGE_DATA, sizeof(nvimgcodecDebugMessageData_t), nullptr,
             message.c_str(), 0, nullptr, name_.c_str(), 0};

--- a/src/parsers/exif.h
+++ b/src/parsers/exif.h
@@ -42,6 +42,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <map>
 #include <utility>


### PR DESCRIPTION
I was building this project with some optional features disabled and ran into CMake and compiler errors.

Specifically, I was trying to build with this configuration.
```bash
cmake .. -GNinja -DBUILD_PYTHON:BOOL=OFF -DBUILD_SAMPLES:BOOL=OFF -DBUILD_TEST:BOOL=OFF -DBUILD_EXTENSIONS:BOOL=ON
```

which resulted:

- in a search for pybind11 and dlpack, but these are not needed unless you are buidling the python modules?
- missing definitions of some integer types. Maybe these definitions are imported elsewhere when building the tests, python modules, or samples?